### PR TITLE
`build_codon_variants` handles insertions in reference site numbers

### DIFF
--- a/notebooks/build_codon_variants.ipynb
+++ b/notebooks/build_codon_variants.ipynb
@@ -432,7 +432,11 @@
     "    .assign(\n",
     "        wildtype=lambda x: x[\"mutation\"].str[0],\n",
     "        mutant=lambda x: x[\"mutation\"].str[-1],\n",
-    "        reference_site=lambda x: x[\"reference_site\"].astype(\"Int64\"),\n",
+    "        reference_site=lambda x: (\n",
+    "            x[\"reference_site\"]\n",
+    "            if all(x[\"reference_site\"] == x[\"reference_site\"].astype(str))\n",
+    "            else x[\"reference_site\"].astype(\"Int64\")\n",
+    "        ),\n",
     "    )\n",
     "    .assign(mutant=lambda x: x[\"mutant\"] + \"=\" + x[\"count\"].astype(str))\n",
     "    .sort_values(\"count\", ascending=False)\n",
@@ -670,7 +674,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes a problem in this notebook for Omicron BA.1 where there are inserted sites number `XXXa`, `XXXb`, etc.