### PR TITLE
pin `matplotlib` to 3.5

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,7 @@ dependencies:
   - jupyterlab
   - mafft=7.505
   - mamba
+  - matplotlib=3.5
   - minimap2=2.24
   - nbdime
   - nbstripout


### PR DESCRIPTION
Needed until this issue is fixed: https://github.com/has2k1/plotnine/issues/621