### PR TITLE
unpin `matplotlib` version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,6 @@ dependencies:
   - mafft=7.505
   - mamba
   - markdown=3.3
-  - matplotlib=3.5
   - minimap2=2.24
   - nbdime
   - nbstripout


### PR DESCRIPTION
Undo the pinning in #78 as `plotnine` has now been updated to work with newer `matplotlib`.