### PR TITLE
Fixed an issue where the default margin in the `Altair` input elements was set to 0 

### DIFF
--- a/scripts/format_altair_html.py
+++ b/scripts/format_altair_html.py
@@ -80,8 +80,10 @@ def annotate_altair_chart(chart_html, annotation_md, twitter_card):
     page.head.style.append(
         "#markdown {margin-left: 2.5%; margin-right: 2.5%; margin-top: 10px; }"
     )
-    # Fix the defaul of no margins around the inputs
-    page.head.style.append("input {margin: 3px !important;}")
+    # Fix the margins and font size for selectors within the vega vis
+    page.head.style.append(
+        "#vis input, #vis label, #vis span {font-size: 14px; margin: 0px 3px 1px 0px;}"
+    )
 
     return page.prettify()
 

--- a/scripts/format_altair_html.py
+++ b/scripts/format_altair_html.py
@@ -80,6 +80,10 @@ def annotate_altair_chart(chart_html, annotation_md, twitter_card):
     page.head.style.append(
         "#markdown {margin-left: 2.5%; margin-right: 2.5%; margin-top: 10px; }"
     )
+    # Fix the defaul of no margins around the inputs
+    page.head.style.append(
+        "input {margin: 3px !important;}"
+    )
 
     return page.prettify()
 

--- a/scripts/format_altair_html.py
+++ b/scripts/format_altair_html.py
@@ -81,9 +81,7 @@ def annotate_altair_chart(chart_html, annotation_md, twitter_card):
         "#markdown {margin-left: 2.5%; margin-right: 2.5%; margin-top: 10px; }"
     )
     # Fix the defaul of no margins around the inputs
-    page.head.style.append(
-        "input {margin: 3px !important;}"
-    )
+    page.head.style.append("input {margin: 3px !important;}")
 
     return page.prettify()
 


### PR DESCRIPTION
I overrode the default `margin: 0px` to add some padding to the `input` elements (i.e., range sliders, radio buttons) in the formatted `Altair` plots.