### PR TITLE
Expanded the regex to match both SSH and HTTPS remote URLs

### DIFF
--- a/pipeline.smk
+++ b/pipeline.smk
@@ -24,7 +24,7 @@ if ("no_github_check" not in config) or (not config["no_github_check"]):
         text=True,
     )
     git_remote_regex = re.match(
-        "origin\thttps://github.com/(?P<user>[\-\w]+)/(?P<repo>[\-\w\.]+)(?: |\.git)",
+        "origin\t(https://|git@)github.com(/|:)(?P<user>[\-\w]+)/(?P<repo>[\-\w\.]+)(?: |\.git)",
         git_remote_res.stdout,
     )
     if not git_remote_regex:


### PR DESCRIPTION
I made a simple change to the `regex` so that it matches both `HTTPS` format remote URLs:

```
https://github.com/dms-vep/dms-vep-pipeline.git
```

and `SSH` format URLs: 

```
git@github.com:dms-vep/dms-vep-pipeline.git
```

I switched the remote for my local branch to `HTTPs` and `SSH` to test the pipeline, and it ran to completion with both remotes. 