### PR TITLE
allow FASTQ to be duplicated if "repeated" in notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### version 1.3.1
+- A FASTQ can be repeated in `barcode_runs.csv` if the *notes* column has the word "repeated" for each repeated row.
+
 ### version 1.3
 - Upgraded `polyclonal` to version 2.5.
 


### PR DESCRIPTION
This addresses #104 by @bblarsen-sci

The solution here is that in order to repeat a FASTQ, the *notes* column in `barcode_runs.csv` for all rows with the repeated entry must have the word "repeated".

This ensures that in general we still have a check that FASTQs are not being re-used, since that could often indicate an error.

But in cases where there is a good reason to re-use one, you will have a note in the *notes* column, like "this FASTQ repeated in replicates XXX and YYY because ZZZ"