### PR TITLE
check for repeated FASTQs works when `barcode_runs` notes all null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - Upgrade `mafft` to 7.508
  - Upgrade `snakemake` to 7.18.2
  - No longer pin `tabulate` version (see #90)
+- Fix check for repeated FASTQs even when *notes* column in `barcode_runs.csv` is all *null*.
 
 #### version 1.3.1
 - A FASTQ can be repeated in `barcode_runs.csv` if the *notes* column has the word "repeated" for each repeated row.

--- a/funcs.smk
+++ b/funcs.smk
@@ -109,10 +109,10 @@ def barcode_runs_from_config(barcode_runs_csv, valid_libraries):
             f"Failed to find some fastqs:\n{fastqs.query('not found_file')}"
         )
     dup_fastqs = fastqs.query("n_occurrences != 1")
-    if (
-        (fastqs["n_occurrences"] != 1)
-        & (~fastqs["notes"].str.contains("repeated", na=False))
-    ).any():
+    if (len(dup_fastqs) > 1) and (
+        (dup_fastqs["notes"].dtype == "float")
+        or not dup_fastqs["notes"].str.contains("repeated", na=False).all()
+    ):
         pd.set_option("display.max_colwidth", None)
         raise ValueError(
             "FASTQs repeated for multiple samples. You can only repeat a FASTQ "


### PR DESCRIPTION
Fixes new bug noticed in re-opening of #104: check for duplicated FASTQs works even when no notes.

@fwelsh, this should fix issue you just re-opened. 