### PR TITLE
update `biopython` to 1.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+#### version 1.4.3
+- Upgrade to `biopython` 1.80.
+
 #### version 1.4.2
 - Plot of functional scores in `analyze_func_scores` separates variants by whether they have only intended or also unintended nonsynonymous mutations.
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - bioconda
 
 dependencies:
-  - biopython=1.79  # pinned to 1.79 rather than 1.80 because of this: https://github.com/Edinburgh-Genome-Foundry/DnaFeaturesViewer/issues/73
+  - biopython=1.80
   - black-jupyter
   - bs4=4.11
   - entrez-direct=16.2


### PR DESCRIPTION
Becomes `dms-vep-pipeline` version 1.4.3.

Enabled by this update to `dna_features_viewer`.