### PR TITLE
enable reuse codon variant table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
   - cd test_example && snakemake --lint && cd ..
   - rm -rf docs && cd test_example && rm -rf results && snakemake -j 2 --use-conda && cd ..
   - rm -rf docs && cd test_example && rm -rf results && snakemake -j 2 --use-conda --config barcode_runs=null && cd ..
+  - rm -rf docs && cd test_example && rm -rf results && snakemake -j 2 --use-conda --config prebuilt_variants=https://raw.githubusercontent.com/dms-vep/dms-vep-pipeline/main/test_example/results/variants/codon_variants.csv prebuilt_geneseq=https://raw.githubusercontent.com/dms-vep/dms-vep-pipeline/main/test_example/results/gene_sequence/codon.fasta
 
 branches:
   only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+### version 1.6.0
+- add option to use pre-built variants
+ - Enables use of pre-built codon-variant table rather than having to rebuild every time.
+ - Add `prebuilt_variants` and `prebuilt_geneseq` options
+ - Move variant building from `pipeline.smk` to `build_variants.smk`
+
 #### version 1.5.2
 - Update `polyclonal` to 3.3
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Running the `Snakefile` in [./test_example](test_example) performs the whole ana
 ## Running the pipeline
 The `Snakefile` you create will include [pipeline.smk](pipeline.smk) (which has the analysis pipeline) and [docs.smk](docs.smk) (which builds the [sphinx](https://www.sphinx-doc.org/) HTML documentation).
 You can also optionally add other rules into your `Snakefile`.
-If they define an `output` named `nb` that is a Jupyter notebook (like some of the rules in [pipeline.smk](pipeline.smk)), then that will be included into the HTML documentation.
+If they define an `output` named `nb` that is a Jupyter notebook (like some of the rules in [pipeline.smk](pipeline.smk) and its included `.smk` files), then that will be included into the HTML documentation.
 
 You then run the pipeline with:
 
@@ -83,6 +83,7 @@ Here are the different contents of this repo:
  - [funcs.smk](funcs.smk) functions used in [snakemake](https://snakemake.readthedocs.io/) pipeline.
  - [LICENSE.txt](LICENSE.txt): license for pipeline.
  - [pipeline.smk](pipeline.smk): [snakemake](https://snakemake.readthedocs.io/) rules that run pipeline.
+ - [build_variants.smk](build_variants.smk): [snakemake](https://snakemake.readthedocs.io/) rules for pipeline specific to building variants, included in [pipeline.smk](pipeline.smk).
  - [./scripts](scripts): subdirectory with scripts used by [snakemake](https://snakemake.readthedocs.io/) rules.
  - [./docs](docs): HTML documentation for the test example.
  - [environment.yml](environment.yml): the [conda](https://docs.conda.io/) environment for the pipeline.

--- a/build_variants.smk
+++ b/build_variants.smk
@@ -1,0 +1,137 @@
+"""``snakemake`` file that includes the pipeline code for building variants."""
+
+pacbio_runs = pacbio_runs_from_config(config["pacbio_runs"])
+
+if "prebuilt_variants" in config and config["prebuilt_variants"]:
+    if not (("prebuilt_geneseq" in config) and config["prebuilt_geneseq"]):
+        raise ValueError(
+            "specify both or neither of `prebuilt_geneseq` and `prebuilt_variants`"
+        )
+
+    rule get_prebuilt_variants:
+        """Get pre-built variants and gene sequence."""
+        output:
+            variants=config["codon_variants"],
+            geneseq=config["gene_sequence_codon"],
+        params:
+            variants_url=config["prebuilt_variants"],
+            geneseq_url=config["prebuilt_geneseq"],
+        conda:
+            "environment.yml"
+        log:
+            os.path.join(config["logdir"], "get_prebuilt_variants.txt"),
+        shell:
+            """
+            curl -o {output.variants} {params.variants_url} &> {log}
+            curl -o {output.geneseq} {params.geneseq_url} &> {log}
+            """
+
+    rule translate_geneseq:
+        """Translate gene sequence into protein sequence."""
+        input:
+            gene=rules.get_prebuilt_variants.output.geneseq,
+        output:
+            prot=config["gene_sequence_protein"],
+        conda:
+            "environment.yml"
+        log:
+            os.path.join(config["logdir"], "translate_geneseq.txt"),
+        script:
+            "scripts/translate_geneseq.py"
+
+else:
+    if ("prebuilt_geneseq" in config) and config["prebuilt_geneseq"]:
+        raise ValueError(
+            "specify both or neither of `prebuilt_geneseq` and `prebuilt_variants`"
+        )
+
+    rule gene_sequence:
+        """Get sequence of gene from PacBio amplicon."""
+        input:
+            gb=config["pacbio_amplicon"],
+        output:
+            codon=config["gene_sequence_codon"],
+            prot=config["gene_sequence_protein"],
+        conda:
+            "environment.yml"
+        log:
+            os.path.join(config["logdir"], "gene_sequence.txt"),
+        script:
+            "scripts/gene_sequence.py"
+
+
+    rule align_parse_PacBio_ccs:
+        """Align and parse PacBio CCS FASTQ file."""
+        input:
+            fastq=lambda wc: pacbio_runs.at[wc.pacbioRun, "fastq"],
+            amplicon=config["pacbio_amplicon"],
+            specs=config["pacbio_amplicon_specs"],
+        output:
+            outdir=directory(os.path.join(config["process_ccs_dir"], "{pacbioRun}")),
+        conda:
+            "environment.yml"
+        log:
+            os.path.join(config["logdir"], "align_parse_PacBio_ccs_{pacbioRun}.txt"),
+        script:
+            "scripts/align_parse_PacBio_ccs.py"
+
+
+    rule analyze_pacbio_ccs:
+        """Analyze PacBio CCSs and get ones that align to amplicons of interest."""
+        input:
+            expand(rules.align_parse_PacBio_ccs.output.outdir, pacbioRun=pacbio_runs.index),
+            config["pacbio_amplicon"],
+            config["pacbio_amplicon_specs"],
+            nb=os.path.join(config["pipeline_path"], "notebooks/analyze_pacbio_ccs.ipynb"),
+        output:
+            config["aligned_ccs_file"],
+            nb="results/notebooks/analyze_pacbio_ccs.ipynb",
+        conda:
+            "environment.yml"
+        log:
+            os.path.join(config["logdir"], "analyze_pacbio_ccs.txt"),
+        shell:
+            "papermill {input.nb} {output.nb} &> {log}"
+
+
+    rule build_pacbio_consensus:
+        """Build PacBio consensus sequences for barcodes."""
+        input:
+            config["aligned_ccs_file"],
+            config["gene_sequence_codon"],
+            nb=os.path.join(
+                config["pipeline_path"], "notebooks/build_pacbio_consensus.ipynb"
+            ),
+        output:
+            config["nt_variants"],
+            nb="results/notebooks/build_pacbio_consensus.ipynb",
+        params:
+            config["max_ccs_error_rate"],
+            config["consensus_params"],
+        conda:
+            "environment.yml"
+        log:
+            os.path.join(config["logdir"], "build_pacbio_consensus.txt"),
+        shell:
+            "papermill {input.nb} {output.nb} &> {log}"
+
+
+    rule build_codon_variants:
+        """Build codon-variant table."""
+        input:
+            config["nt_variants"],
+            config["gene_sequence_codon"],
+            config["gene_sequence_protein"],
+            config["site_numbering_map"],
+            config["mutation_design_classification"],
+            config["neut_standard_barcodes"],
+            nb=os.path.join(config["pipeline_path"], "notebooks/build_codon_variants.ipynb"),
+        output:
+            config["codon_variants"],
+            nb="results/notebooks/build_codon_variants.ipynb",
+        conda:
+            "environment.yml"
+        log:
+            os.path.join(config["logdir"], "build_codon_variants.txt"),
+        shell:
+            "papermill {input.nb} {output.nb} &> {log}"

--- a/funcs.smk
+++ b/funcs.smk
@@ -32,7 +32,7 @@ SAMPLE_TYPES = frozendict.frozendict(
 """frozendict.frozendict: Map sample type synonyms in barcode runs to sample type."""
 
 
-def barcode_runs_from_config(barcode_runs_csv, valid_libraries):
+def barcode_runs_from_config(barcode_runs_csv):
     """Data frame of barcode runs from input CSV."""
 
     # expected columns in final output
@@ -57,8 +57,6 @@ def barcode_runs_from_config(barcode_runs_csv, valid_libraries):
 
     def process_sample(row):
         """Internal function that processes rows in data frame."""
-        if row["library"] not in valid_libraries:
-            raise ValueError(f"{row['library']=} not in {valid_libraries=}\n{row=}")
         label_cols = ["date", "virus_batch", "sample_type"]
         if SAMPLE_TYPES[row["sample_type"]] == "antibody":
             label_cols += ["antibody", "antibody_concentration"]

--- a/notebooks/avg_muteffects.ipynb
+++ b/notebooks/avg_muteffects.ipynb
@@ -501,7 +501,6 @@
     "    )\n",
     "\n",
     "for phenotype, df in df_to_plot.groupby(\"phenotype\"):\n",
-    "\n",
     "    print(f\"\\n{phenotype} phenotype\\n\")\n",
     "\n",
     "    plot_kwargs[\"plot_title\"] = f\"functional effects ({phenotype} phenotype)\"\n",

--- a/notebooks/fit_globalepistasis.ipynb
+++ b/notebooks/fit_globalepistasis.ipynb
@@ -501,7 +501,6 @@
     "        plot_kwargs[\"addtl_tooltip_stats\"].append(\"sequential_site\")\n",
     "\n",
     "for phenotype, df in df_to_plot.groupby(\"phenotype\"):\n",
-    "\n",
     "    print(f\"\\n{phenotype} phenotype\\n\")\n",
     "\n",
     "    plot_kwargs[\"plot_title\"] = f\"functional effects ({phenotype} phenotype)\"\n",

--- a/pipeline.smk
+++ b/pipeline.smk
@@ -48,12 +48,7 @@ github_pages_url = f"https://{config['github_user']}.github.io/{config['github_r
 # Data frames for PacBio runs, Illumina barcode runs, antibody selections, etc.
 # Some of these are written to CSV files, but only if they have changed.
 
-pacbio_runs = pacbio_runs_from_config(config["pacbio_runs"])
-
-barcode_runs = barcode_runs_from_config(
-    config["barcode_runs"],
-    valid_libraries=set(pacbio_runs["library"]),
-)
+barcode_runs = barcode_runs_from_config(config["barcode_runs"])
 os.makedirs(os.path.dirname(config["processed_barcode_runs"]), exist_ok=True)
 to_csv_if_changed(barcode_runs, config["processed_barcode_runs"], index=False)
 
@@ -136,98 +131,7 @@ muteffects_files = [
 
 # Rules ---------------------------------------------------------------------
 
-
-rule gene_sequence:
-    """Get sequence of gene from PacBio amplicon."""
-    input:
-        gb=config["pacbio_amplicon"],
-    output:
-        codon=config["gene_sequence_codon"],
-        prot=config["gene_sequence_protein"],
-    conda:
-        "environment.yml"
-    log:
-        os.path.join(config["logdir"], "gene_sequence.txt"),
-    script:
-        "scripts/gene_sequence.py"
-
-
-rule align_parse_PacBio_ccs:
-    """Align and parse PacBio CCS FASTQ file."""
-    input:
-        fastq=lambda wc: pacbio_runs.at[wc.pacbioRun, "fastq"],
-        amplicon=config["pacbio_amplicon"],
-        specs=config["pacbio_amplicon_specs"],
-    output:
-        outdir=directory(os.path.join(config["process_ccs_dir"], "{pacbioRun}")),
-    conda:
-        "environment.yml"
-    log:
-        os.path.join(config["logdir"], "align_parse_PacBio_ccs_{pacbioRun}.txt"),
-    script:
-        "scripts/align_parse_PacBio_ccs.py"
-
-
-rule analyze_pacbio_ccs:
-    """Analyze PacBio CCSs and get ones that align to amplicons of interest."""
-    input:
-        expand(rules.align_parse_PacBio_ccs.output.outdir, pacbioRun=pacbio_runs.index),
-        config["pacbio_amplicon"],
-        config["pacbio_amplicon_specs"],
-        nb=os.path.join(config["pipeline_path"], "notebooks/analyze_pacbio_ccs.ipynb"),
-    output:
-        config["aligned_ccs_file"],
-        nb="results/notebooks/analyze_pacbio_ccs.ipynb",
-    conda:
-        "environment.yml"
-    log:
-        os.path.join(config["logdir"], "analyze_pacbio_ccs.txt"),
-    shell:
-        "papermill {input.nb} {output.nb} &> {log}"
-
-
-rule build_pacbio_consensus:
-    """Build PacBio consensus sequences for barcodes."""
-    input:
-        config["aligned_ccs_file"],
-        config["gene_sequence_codon"],
-        nb=os.path.join(
-            config["pipeline_path"], "notebooks/build_pacbio_consensus.ipynb"
-        ),
-    output:
-        config["nt_variants"],
-        nb="results/notebooks/build_pacbio_consensus.ipynb",
-    params:
-        config["max_ccs_error_rate"],
-        config["consensus_params"],
-    conda:
-        "environment.yml"
-    log:
-        os.path.join(config["logdir"], "build_pacbio_consensus.txt"),
-    shell:
-        "papermill {input.nb} {output.nb} &> {log}"
-
-
-rule build_codon_variants:
-    """Build codon-variant table."""
-    input:
-        config["nt_variants"],
-        config["gene_sequence_codon"],
-        config["gene_sequence_protein"],
-        config["site_numbering_map"],
-        config["mutation_design_classification"],
-        config["neut_standard_barcodes"],
-        nb=os.path.join(config["pipeline_path"], "notebooks/build_codon_variants.ipynb"),
-    output:
-        config["codon_variants"],
-        nb="results/notebooks/build_codon_variants.ipynb",
-    conda:
-        "environment.yml"
-    log:
-        os.path.join(config["logdir"], "build_codon_variants.txt"),
-    shell:
-        "papermill {input.nb} {output.nb} &> {log}"
-
+include: "build_variants.smk"  # build variants with included rules
 
 rule count_barcodes:
     """Count barcodes for a specific library-sample."""

--- a/scripts/format_altair_html.py
+++ b/scripts/format_altair_html.py
@@ -89,7 +89,6 @@ def annotate_altair_chart(chart_html, annotation_md, twitter_card):
 
 
 if __name__ == "__main__":
-
     # Command line interface
     parser = argparse.ArgumentParser(
         description="Format HTML file containing embeded Vega spec saved with Altair."

--- a/scripts/translate_geneseq.py
+++ b/scripts/translate_geneseq.py
@@ -1,0 +1,19 @@
+"""Implements ``snakemake`` rule to translate gene sequence."""
+
+
+import sys
+
+import Bio.SeqIO
+
+
+sys.stderr = sys.stdout = log = open(snakemake.log[0], "w")
+
+gene = Bio.SeqIO.read(snakemake.input.gene, "fasta").seq
+
+# first make sure gene can translate as CDS
+_ = gene.translate(cds=True)
+# now translate without cds flag to keep any stop codons
+protseq = gene.translate()
+
+with open(snakemake.output.prot, "w") as f:
+    f.write(f">gene\n{str(protseq)}\n")

--- a/test_example/config.yaml
+++ b/test_example/config.yaml
@@ -16,12 +16,25 @@ github_repo: dms-vep-pipeline
 github_user: dms-vep
 github_branch: main  # main branch for repo, assume renamed from master -> main
 description: Deep mutational scanning (DMS) pipeline for a viral entry protein (VEP)
-year: 2022
+year: 2023
 authors: Jesse Bloom
 
 # ----------------------------------------------------------------------------
-# Parameters for analysis
+# Parameters related to building the codon variants
 # ----------------------------------------------------------------------------
+
+# There are two ways you can get the codon variants: download a pre-built codon
+# variant table, or build them from PacBio CCSs yourself. If you are using
+# pre-built ones, then specify the links to URLs giving the codon variants,
+# gene sequence, and protein sequence for the pre-built table under `prebuilt_variants`.
+# Otherwise, specify the other variables. If `prebuilt_variants` is specified, all
+# other variables in this section are ignored (and do not need to be specified at all).
+
+# If using pre-built variants specify URL for pre-built codon-variant table
+# and gene (codon) sequence.
+# prebuilt_variants: https://raw.githubusercontent.com/dms-vep/dms-vep-pipeline/main/test_example/results/variants/codon_variants.csv
+# prebuilt_geneseq: https://raw.githubusercontent.com/dms-vep/dms-vep-pipeline/main/test_example/results/gene_sequence/codon.fasta
+
 # Parameters for building PacBio CCS consensuses
 max_ccs_error_rate: 1.0e-4  # only keep CCS if gene/barcode error rate <= this
 consensus_params:  # parameters for building PacBio consensus sequences
@@ -30,6 +43,24 @@ consensus_params:  # parameters for building PacBio consensus sequences
   max_minor_sub_frac: 0.2
   max_minor_indel_frac: 0.2
   min_support: 2
+
+# PacBio sequencing
+pacbio_runs: data/PacBio_runs.csv  # PacBio sequencing data
+pacbio_amplicon: data/PacBio_amplicon.gb  # Genbank file with PacBio amplicon
+pacbio_amplicon_specs: data/PacBio_feature_parse_specs.yaml  # alignparse feature parsing
+variant_tags:  # variant tags in PacBio amplicon, or "null" if no tags
+  variant_tag5:
+    variant_1: G
+    variant_2: C
+    wildtype: A
+  variant_tag3:
+    variant_1: G
+    variant_2: C
+    wildtype: A
+
+# ----------------------------------------------------------------------------
+# Parameters for analyses downstream of building the codon variants
+# ----------------------------------------------------------------------------
 
 # Parameters for processing Illumina barcodes
 illumina_barcode_parser_params:
@@ -77,30 +108,17 @@ muteffects_plot_kwargs:
   init_floor_at_zero: False
 
 # do we add formatting to the antibody escape and functional effects plots
-format_antibody_escape_plots: true  # if option, missing defaults to true
-format_muteffects_plots: true  # if option, missing defaults to true
+format_antibody_escape_plots: true  # if option missing defaults to true
+format_muteffects_plots: true  # if option missing defaults to true
 # to override default, provide a value for antibody_escape_legend / muteffects_legend
 antibody_escape_legend: null
 muteffects_legend: null
 
 # ----------------------------------------------------------------------------
-# Input data to dms-vep-pipeline
+# Input data to dms-vep-pipeline downstream of building codon variants
 # ----------------------------------------------------------------------------
-# PacBio sequencing
-pacbio_runs: data/PacBio_runs.csv  # PacBio sequencing data
-pacbio_amplicon: data/PacBio_amplicon.gb  # Genbank file with PacBio amplicon
-pacbio_amplicon_specs: data/PacBio_feature_parse_specs.yaml  # alignparse feature parsing
-variant_tags:  # variant tags in PacBio amplicon, or "null" if no tags
-  variant_tag5:
-    variant_1: G
-    variant_2: C
-    wildtype: A
-  variant_tag3:
-    variant_1: G
-    variant_2: C
-    wildtype: A
 
-# Map sequential 1, 2, numbering of gene in PacBio amplicon to the desired
+# Map sequential 1, 2, numbering of the protein to the desired
 # final reference numbering scheme. Required to have columns named
 # "sequential_site" and "reference_site". If you just want to number in
 # sequential numbering for everything, just make both entries sequential.


### PR DESCRIPTION
Enable re-use of codon variant table by providing option to specify in `config.yml` the URLs to `prebuilt_variants` and `prebuilt_geneseq` which then just download the codon-variant table from another source.

Useful for repos that are using variants already linked to barcodes by PacBio and so don't need to repeat all of those steps.

Note internally some of the steps have been moved from `pipeline.smk` to `build_variants.smk`.

Partially addresses #120 by simply removing the need to do any PacBio processing from some repos.

Becomes version 1.6.0.