### PR TITLE
fix bug in using pre-built variants with no `pacbio_runs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+#### version 1.6.1
+- Fix bug in using pre-built variants when no `pacbio_runs` file provided.
+
 ### version 1.6.0
 - add option to use pre-built variants
  - Enables use of pre-built codon-variant table rather than having to rebuild every time.

--- a/build_variants.smk
+++ b/build_variants.smk
@@ -1,6 +1,5 @@
 """``snakemake`` file that includes the pipeline code for building variants."""
 
-pacbio_runs = pacbio_runs_from_config(config["pacbio_runs"])
 
 if "prebuilt_variants" in config and config["prebuilt_variants"]:
     if not (("prebuilt_geneseq" in config) and config["prebuilt_geneseq"]):
@@ -44,6 +43,8 @@ else:
         raise ValueError(
             "specify both or neither of `prebuilt_geneseq` and `prebuilt_variants`"
         )
+            
+    pacbio_runs = pacbio_runs_from_config(config["pacbio_runs"])
 
     rule gene_sequence:
         """Get sequence of gene from PacBio amplicon."""


### PR DESCRIPTION
Fixes bug introduced in version 1.6.0, becomes version 1.6.1