### PR TITLE
add `prebuilt_muteffects` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - cd test_example && snakemake --lint && cd ..
   - rm -rf docs && cd test_example && rm -rf results && snakemake -j 2 --use-conda && cd ..
   - rm -rf docs && cd test_example && rm -rf results && snakemake -j 2 --use-conda --config barcode_runs=null && cd ..
-  - rm -rf docs && cd test_example && rm -rf results && snakemake -j 2 --use-conda --config prebuilt_variants=https://raw.githubusercontent.com/dms-vep/dms-vep-pipeline/main/test_example/results/variants/codon_variants.csv prebuilt_geneseq=https://raw.githubusercontent.com/dms-vep/dms-vep-pipeline/main/test_example/results/gene_sequence/codon.fasta
+  - rm -rf docs && cd test_example && rm -rf results && snakemake -j 2 --use-conda --config prebuilt_variants=https://raw.githubusercontent.com/dms-vep/dms-vep-pipeline/main/test_example/results/variants/codon_variants.csv prebuilt_geneseq=https://raw.githubusercontent.com/dms-vep/dms-vep-pipeline/main/test_example/results/gene_sequence/codon.fasta prebuilt_muteffects=https://raw.githubusercontent.com/dms-vep/dms-vep-pipeline/main/test_example/results/muteffects_functional/muteffects_observed.csv
 
 branches:
   only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+### version 1.7.0
+- add option to use pre-built mutational effects.
+ - Enables use of functional scores from another repo, do not calculate here. Useful for small repos that for instance might add another antibody to an already extensively studied library.
+ - Add `prebuilt_muteffects` option in `config.yaml`.
+ - Move functional score computation from `pipeline.smk` to `func_scores.smk`
+
 #### version 1.6.1
 - Fix bug in using pre-built variants when no `pacbio_runs` file provided.
 

--- a/docs.smk
+++ b/docs.smk
@@ -25,7 +25,11 @@ nb_rule_wildcards = {
         "antibody_selection_group": antibody_selections["selection_group"].unique(),
     },
     "fit_globalepistasis": {
-        "func_selection": func_selections["selection_name"].unique(),
+        "func_selection": (
+            func_selections["selection_name"].unique()
+            if len(func_selections) > 0
+            else []
+        ),
     },
     "avg_antibody_escape": {
         "antibody": antibody_selections["antibody"].unique(),
@@ -170,8 +174,8 @@ rule subindex:
     wildcard_constraints:
         subindex=(
             "|".join(re.escape(subindex) for subindex in nb_subindices)
-        if nb_subindices
-        else "a^"
+            if nb_subindices
+            else "a^"
         ),
     input:
         lambda wc: nb_subindices[wc.subindex],

--- a/func_scores.smk
+++ b/func_scores.smk
@@ -1,0 +1,261 @@
+"""``snakemake`` file for functional scores steps of pipeline."""
+
+if "prebuilt_muteffects" in config and config["prebuilt_muteffects"]:
+    # Use pre-built mutational effects
+    have_muteffects = True
+    func_selections = pd.DataFrame()  # make empty data frame as no func selections
+    muteffects_plots = {}
+
+    rule get_muteffects:
+        """Get prebuilt mutational effects."""
+        output:
+            muteffects=config["muteffects_observed"],
+        params:
+            url=config["prebuilt_muteffects"],
+        conda:
+            "environment.yml"
+        log:
+            os.path.join(config["logdir"], "get_muteffects.txt"),
+        shell:
+            "curl -o {output.muteffects} {params.url} &> {log}"
+
+else:
+    # Compute functional scores and mutational effects de novo
+    func_selections = get_functional_selections(barcode_runs)
+    os.makedirs(os.path.dirname(config["functional_selections"]), exist_ok=True)
+    to_csv_if_changed(func_selections, config["functional_selections"], index=False)
+    func_selections_dict = func_selections.set_index("selection_name").to_dict(
+        orient="index"
+    )
+
+    func_score_files = [
+        os.path.join(config["func_score_dir"], f"{func_selection}_func_scores.csv")
+        for func_selection in func_selections["selection_name"]
+    ]
+
+    if len(func_selections):
+        muteffects_plots = {
+            f"muteffects_{pheno}_heatmap": os.path.splitext(
+                config[f"muteffects_{pheno}"]
+            )[0]
+            + "_heatmap.html"
+            for pheno in ["observed", "latent"]
+        }
+        have_muteffects = True
+    else:
+        muteffects_plots = {}
+        have_muteffects = False
+
+    muteffects_files = [
+        os.path.join(
+            config["globalepistasis_dir"],
+            f"{func_selection}_muteffects_{phenotype}.csv",
+        )
+        for func_selection in func_selections["selection_name"]
+        for phenotype in ["latent", "observed"]
+    ]
+
+    rule func_scores:
+        """Compute functional scores for variants."""
+        input:
+            gene_sequence_codon=config["gene_sequence_codon"],
+            codon_variants=config["codon_variants"],
+            site_numbering_map=config["site_numbering_map"],
+            preselection=lambda wc: os.path.join(
+                config["variant_counts_dir"],
+                func_selections_dict[wc.func_selection]["preselection_library_sample"]
+                + ".csv",
+            ),
+            postselection=lambda wc: os.path.join(
+                config["variant_counts_dir"],
+                func_selections_dict[wc.func_selection]["postselection_library_sample"]
+                + ".csv",
+            ),
+        output:
+            func_scores=os.path.join(
+                config["func_score_dir"],
+                "{func_selection}_func_scores.csv",
+            ),
+        params:
+            library=lambda wc: func_selections_dict[wc.func_selection]["library"],
+            preselection_sample=lambda wc: func_selections_dict[wc.func_selection][
+                "preselection_sample"
+            ],
+            postselection_sample=lambda wc: func_selections_dict[wc.func_selection][
+                "postselection_sample"
+            ],
+            pseudocount=config["func_scores_pseudocount"],
+            min_wt_count=config["func_scores_min_wt_count"],
+            min_wt_frac=config["func_scores_min_wt_frac"],
+            min_preselection_counts=config["func_scores_min_preselection_counts"],
+            min_preselection_frac=config["func_scores_min_preselection_frac"],
+        conda:
+            "environment.yml"
+        log:
+            os.path.join(config["logdir"], "func_scores_{func_selection}.txt"),
+        script:
+            "scripts/func_scores.py"
+
+    rule analyze_func_scores:
+        """Analyze the functional scores."""
+        input:
+            func_score_files,
+            config["functional_selections"],
+            config["mutation_design_classification"],
+            nb=os.path.join(
+                config["pipeline_path"], "notebooks/analyze_func_scores.ipynb"
+            ),
+        output:
+            # only make a notebook output for docs if there are functional selections
+            **(
+                {"nb": "results/notebooks/analyze_func_scores.ipynb"}
+                if len(func_selections)
+                else {}
+            ),
+        conda:
+            "environment.yml"
+        log:
+            os.path.join(config["logdir"], "analyze_func_scores.txt"),
+        shell:
+            "papermill {input.nb} {output.nb} &> {log}"
+
+    rule fit_globalepistasis:
+        """Fit global epistasis models to variant functional scores to get muteffects."""
+        input:
+            func_scores_csv=rules.func_scores.output.func_scores,
+            site_numbering_map=config["site_numbering_map"],
+            nb=os.path.join(
+                config["pipeline_path"], "notebooks/fit_globalepistasis.ipynb"
+            ),
+        output:
+            pickle=os.path.join(
+                config["globalepistasis_dir"], "{func_selection}.pickle"
+            ),
+            muteffects_latent=os.path.join(
+                config["globalepistasis_dir"],
+                "{func_selection}_muteffects_latent.csv",
+            ),
+            muteffects_observed=os.path.join(
+                config["globalepistasis_dir"],
+                "{func_selection}_muteffects_observed.csv",
+            ),
+            nb="results/notebooks/fit_globalepistasis_{func_selection}.ipynb",
+        params:
+            func_scores_floor=(
+                config["func_scores_floor"] if "func_scores_floor" in config else None
+            ),
+            plot_kwargs_yaml=yaml.dump(
+                {"plot_kwargs": config["muteffects_plot_kwargs"]}
+            ),
+            likelihood=(
+                config["epistasis_model_likelihood"]
+                if "epistasis_model_likelihood" in config
+                else "Gaussian"
+            ),
+            ftol=(
+                config["epistasis_model_ftol"]
+                if "epistasis_model_ftol" in config
+                else 1e-7
+            ),
+        conda:
+            "environment.yml"
+        log:
+            os.path.join(config["logdir"], "fit_globalepistasis_{func_selection}.txt"),
+        shell:
+            """
+            papermill {input.nb} {output.nb} \
+                -p func_scores_csv {input.func_scores_csv} \
+                -p sitenumbering_map_csv {input.site_numbering_map} \
+                -p pickle_file {output.pickle} \
+                -p muteffects_latent_csv {output.muteffects_latent} \
+                -p muteffects_observed_csv {output.muteffects_observed} \
+                -p func_scores_floor {params.func_scores_floor} \
+                -p likelihood {params.likelihood} \
+                -p ftol {params.ftol} \
+                -y "{params.plot_kwargs_yaml}" \
+                &> {log}
+            """
+
+    rule avg_muteffects:
+        """Average the mutation effects on viral entry across replicates and libraries."""
+        input:
+            config["functional_selections"],
+            expand(
+                rules.fit_globalepistasis.output.muteffects_latent,
+                func_selection=func_selections["selection_name"],
+            ),
+            expand(
+                rules.fit_globalepistasis.output.muteffects_observed,
+                func_selection=func_selections["selection_name"],
+            ),
+            nb=os.path.join(config["pipeline_path"], "notebooks/avg_muteffects.ipynb"),
+        output:
+            config["muteffects_observed"],
+            config["muteffects_latent"],
+            os.path.splitext(config["muteffects_observed"])[0]
+            + "_heatmap_unformatted.html",
+            os.path.splitext(config["muteffects_latent"])[0]
+            + "_heatmap_unformatted.html",
+            # only make a notebook output for docs if there are functional selections
+            **(
+                {"nb": "results/notebooks/avg_muteffects.ipynb"}
+                if len(func_selections)
+                else {}
+            ),
+        params:
+            config["muteffects_plot_kwargs"],
+            config["muteffects_avg_method"],
+        conda:
+            "environment.yml"
+        log:
+            os.path.join(config["logdir"], "avg_muteffects.txt"),
+        shell:
+            "papermill {input.nb} {output.nb} &> {log}"
+
+    rule format_muteffects_plot:
+        """Format muteffects plot."""
+        input:
+            chart=(
+                "results/muteffects_functional/muteffects_{pheno}_heatmap_unformatted.html"
+            ),
+            md=(
+                config["muteffects_legend"]
+                if "muteffects_legend" in config and config["muteffects_legend"]
+                else os.path.join(
+                    config["pipeline_path"], "plot_legends/muteffects_legend.md"
+                )
+            ),
+            pyscript=os.path.join(
+                config["pipeline_path"], "scripts/format_altair_html.py"
+            ),
+        output:
+            chart="results/muteffects_functional/muteffects_{pheno}_heatmap.html",
+        params:
+            format_plot=int(
+                ("format_muteffects_plots" not in config)
+                or config["format_muteffects_plots"]
+            ),
+            site=lambda _, output: os.path.join(
+                github_pages_url,
+                os.path.basename(output.chart),
+            ),
+            title=f"mutation effects for {config['github_repo']}",
+        conda:
+            "environment.yml"
+        log:
+            os.path.join(config["logdir"], "format_muteffects_plot_{pheno}.txt"),
+        shell:
+            """
+            if [[ {params.format_plot} -eq 1 ]]; then
+                python {input.pyscript} \
+                    --chart {input.chart} \
+                    --markdown {input.md} \
+                    --site "{params.site}" \
+                    --title "{params.title}" \
+                    --description "Mutational effects on {wildcards.pheno} phenotype" \
+                    --output {output} \
+                    &> {log}
+            else
+                cp {input.chart} {output.chart}
+            fi
+            """

--- a/pipeline.smk
+++ b/pipeline.smk
@@ -96,42 +96,11 @@ antibody_escape_plots = [
     for antibody in antibody_selections["antibody"].unique()
 ]
 
-func_selections = get_functional_selections(barcode_runs)
-os.makedirs(os.path.dirname(config["functional_selections"]), exist_ok=True)
-to_csv_if_changed(func_selections, config["functional_selections"], index=False)
-func_selections_dict = func_selections.set_index("selection_name").to_dict(
-    orient="index"
-)
-
-func_score_files = [
-    os.path.join(config["func_score_dir"], f"{func_selection}_func_scores.csv")
-    for func_selection in func_selections["selection_name"]
-]
-
-if len(func_selections):
-    muteffects_plots = {
-        f"muteffects_{pheno}_heatmap": os.path.splitext(config[f"muteffects_{pheno}"])[
-            0
-        ]
-        + "_heatmap.html"
-        for pheno in ["observed", "latent"]
-    }
-else:
-    muteffects_plots = {}
-
-muteffects_files = [
-    os.path.join(
-        config["globalepistasis_dir"],
-        f"{func_selection}_muteffects_{phenotype}.csv",
-    )
-    for func_selection in func_selections["selection_name"]
-    for phenotype in ["latent", "observed"]
-]
-
 
 # Rules ---------------------------------------------------------------------
 
 include: "build_variants.smk"  # build variants with included rules
+include: "func_scores.smk"  # get functional scores with included rules
 
 rule count_barcodes:
     """Count barcodes for a specific library-sample."""
@@ -248,158 +217,6 @@ rule check_adequate_variant_counts:
         os.path.join(config["logdir"], "check_adequate_variant_counts.txt"),
     script:
         "scripts/check_adequate_variant_counts.py"
-
-
-rule func_scores:
-    """Compute functional scores for variants."""
-    input:
-        ancient(rules.check_adequate_variant_counts.output.passed),
-        gene_sequence_codon=config["gene_sequence_codon"],
-        codon_variants=config["codon_variants"],
-        site_numbering_map=config["site_numbering_map"],
-        preselection=lambda wc: os.path.join(
-            config["variant_counts_dir"],
-            func_selections_dict[wc.func_selection]["preselection_library_sample"]
-            + ".csv",
-        ),
-        postselection=lambda wc: os.path.join(
-            config["variant_counts_dir"],
-            func_selections_dict[wc.func_selection]["postselection_library_sample"]
-            + ".csv",
-        ),
-    output:
-        func_scores=os.path.join(
-            config["func_score_dir"],
-            "{func_selection}_func_scores.csv",
-        ),
-    params:
-        library=lambda wc: func_selections_dict[wc.func_selection]["library"],
-        preselection_sample=lambda wc: func_selections_dict[wc.func_selection][
-            "preselection_sample"
-        ],
-        postselection_sample=lambda wc: func_selections_dict[wc.func_selection][
-            "postselection_sample"
-        ],
-        pseudocount=config["func_scores_pseudocount"],
-        min_wt_count=config["func_scores_min_wt_count"],
-        min_wt_frac=config["func_scores_min_wt_frac"],
-        min_preselection_counts=config["func_scores_min_preselection_counts"],
-        min_preselection_frac=config["func_scores_min_preselection_frac"],
-    conda:
-        "environment.yml"
-    log:
-        os.path.join(config["logdir"], "func_scores_{func_selection}.txt"),
-    script:
-        "scripts/func_scores.py"
-
-
-rule analyze_func_scores:
-    """Analyze the functional scores."""
-    input:
-        func_score_files,
-        config["functional_selections"],
-        config["mutation_design_classification"],
-        nb=os.path.join(config["pipeline_path"], "notebooks/analyze_func_scores.ipynb"),
-    output:
-        # only make a notebook output for docs if there are functional selections
-        **(
-            {"nb": "results/notebooks/analyze_func_scores.ipynb"}
-            if len(func_selections)
-            else {}
-        ),
-    conda:
-        "environment.yml"
-    log:
-        os.path.join(config["logdir"], "analyze_func_scores.txt"),
-    shell:
-        "papermill {input.nb} {output.nb} &> {log}"
-
-
-rule fit_globalepistasis:
-    """Fit global epistasis models to variant functional scores to get muteffects."""
-    input:
-        func_scores_csv=rules.func_scores.output.func_scores,
-        site_numbering_map=config["site_numbering_map"],
-        nb=os.path.join(config["pipeline_path"], "notebooks/fit_globalepistasis.ipynb"),
-    output:
-        pickle=os.path.join(config["globalepistasis_dir"], "{func_selection}.pickle"),
-        muteffects_latent=os.path.join(
-            config["globalepistasis_dir"],
-            "{func_selection}_muteffects_latent.csv",
-        ),
-        muteffects_observed=os.path.join(
-            config["globalepistasis_dir"],
-            "{func_selection}_muteffects_observed.csv",
-        ),
-        nb="results/notebooks/fit_globalepistasis_{func_selection}.ipynb",
-    params:
-        func_scores_floor=(
-            config["func_scores_floor"] if "func_scores_floor" in config else None
-        ),
-        plot_kwargs_yaml=yaml.dump({"plot_kwargs": config["muteffects_plot_kwargs"]}),
-        likelihood=(
-            config["epistasis_model_likelihood"]
-            if "epistasis_model_likelihood" in config
-            else "Gaussian"
-        ),
-        ftol=(
-            config["epistasis_model_ftol"]
-            if "epistasis_model_ftol" in config
-            else 1e-7
-        ),
-    conda:
-        "environment.yml"
-    log:
-        os.path.join(config["logdir"], "fit_globalepistasis_{func_selection}.txt"),
-    shell:
-        """
-        papermill {input.nb} {output.nb} \
-            -p func_scores_csv {input.func_scores_csv} \
-            -p sitenumbering_map_csv {input.site_numbering_map} \
-            -p pickle_file {output.pickle} \
-            -p muteffects_latent_csv {output.muteffects_latent} \
-            -p muteffects_observed_csv {output.muteffects_observed} \
-            -p func_scores_floor {params.func_scores_floor} \
-            -p likelihood {params.likelihood} \
-            -p ftol {params.ftol} \
-            -y "{params.plot_kwargs_yaml}" \
-            &> {log}
-        """
-
-
-rule avg_muteffects:
-    """Average the mutation effects on viral entry across replicates and libraries."""
-    input:
-        config["functional_selections"],
-        expand(
-            rules.fit_globalepistasis.output.muteffects_latent,
-            func_selection=func_selections["selection_name"],
-        ),
-        expand(
-            rules.fit_globalepistasis.output.muteffects_observed,
-            func_selection=func_selections["selection_name"],
-        ),
-        nb=os.path.join(config["pipeline_path"], "notebooks/avg_muteffects.ipynb"),
-    output:
-        config["muteffects_observed"],
-        config["muteffects_latent"],
-        os.path.splitext(config["muteffects_observed"])[0] + "_heatmap_unformatted.html",
-        os.path.splitext(config["muteffects_latent"])[0] + "_heatmap_unformatted.html",
-        # only make a notebook output for docs if there are functional selections
-        **(
-            {"nb": "results/notebooks/avg_muteffects.ipynb"}
-            if len(func_selections)
-            else {}
-        ),
-    params:
-        config["muteffects_plot_kwargs"],
-        config["muteffects_avg_method"],
-    conda:
-        "environment.yml"
-    log:
-        os.path.join(config["logdir"], "avg_muteffects.txt"),
-    shell:
-        "papermill {input.nb} {output.nb} &> {log}"
 
 
 rule prob_escape:
@@ -530,11 +347,7 @@ rule fit_polyclonal:
 rule avg_antibody_escape:
     """Average escape for an antibody or serum."""
     input:
-        **(
-            {"muteffects": config["muteffects_observed"]}
-            if len(func_selections)
-            else {}
-        ),
+        **({"muteffects": config["muteffects_observed"]} if have_muteffects else {}),
         site_numbering_map=config["site_numbering_map"],
         polyclonal_config=config["polyclonal_config"],
         selection_group_pickles=lambda wc: expand(
@@ -583,7 +396,7 @@ rule avg_antibody_escape:
                 )
             }
         ),
-        muteffects=lambda _, input: input.muteffects if len(func_selections) else "none",
+        muteffects=lambda _, input: input.muteffects if have_muteffects else "none",
     conda:
         "environment.yml"
     log:
@@ -602,53 +415,6 @@ rule avg_antibody_escape:
             -p escape_plot {output.escape_plot} \
             -y "{params.selection_groups_yaml}" \
             &> {log}
-        """
-
-
-rule format_muteffects_plot:
-    """Format muteffects plot."""
-    input:
-        chart=(
-            "results/muteffects_functional/muteffects_{pheno}_heatmap_unformatted.html"
-        ),
-        md=(
-            config["muteffects_legend"]
-            if "muteffects_legend" in config and config["muteffects_legend"]
-            else os.path.join(
-                config["pipeline_path"], "plot_legends/muteffects_legend.md"
-            )
-        ),
-        pyscript=os.path.join(config["pipeline_path"], "scripts/format_altair_html.py"),
-    output:
-        chart="results/muteffects_functional/muteffects_{pheno}_heatmap.html",
-    params:
-        format_plot=int(
-            ("format_muteffects_plots" not in config)
-            or config["format_muteffects_plots"]
-        ),
-        site=lambda _, output: os.path.join(
-            github_pages_url,
-            os.path.basename(output.chart),
-        ),
-        title=f"mutation effects for {config['github_repo']}",
-    conda:
-        "environment.yml"
-    log:
-        os.path.join(config["logdir"], "format_muteffects_plot_{pheno}.txt"),
-    shell:
-        """
-        if [[ {params.format_plot} -eq 1 ]]; then
-            python {input.pyscript} \
-                --chart {input.chart} \
-                --markdown {input.md} \
-                --site "{params.site}" \
-                --title "{params.title}" \
-                --description "Mutational effects on {wildcards.pheno} phenotype" \
-                --output {output} \
-                &> {log}
-        else
-            cp {input.chart} {output.chart}
-        fi
         """
 
 

--- a/test_example/config.yaml
+++ b/test_example/config.yaml
@@ -59,7 +59,39 @@ variant_tags:  # variant tags in PacBio amplicon, or "null" if no tags
     wildtype: A
 
 # ----------------------------------------------------------------------------
-# Parameters for analyses downstream of building the codon variants
+# Parameters related to computing functional scores
+# ----------------------------------------------------------------------------
+
+# If you want to use prebuilt functional scores just taken from another repo, then
+# set the `prebuilt_muteffects` variable below to the URL for pre-built effects of
+# mutations on the observed phenotype. In that case, all other variables specified in this
+# section will be ignored and can be deleted.
+# prebuilt_muteffects: https://raw.githubusercontent.com/dms-vep/dms-vep-pipeline/main/test_example/results/muteffects_functional/muteffects_observed.csv
+
+# Parameters for functional scores and global epistasis analysis, only needed if not using
+# `prebuilt_muteffects`.
+func_scores_pseudocount: 0.5  # pseudocount when computing functional scores
+func_scores_min_wt_count: 1000  # require this many wildtype counts or error
+func_scores_min_wt_frac:  0.001  # require this fraction of all counts for wildtype or error
+# Only fit global epistasis models for variants with at least this many
+# pre-selection counts and this fraction of total pre-selection counts
+func_scores_min_preselection_counts: 10  # maybe make larger for real expts, say 20 to 50
+func_scores_min_preselection_frac: 0.00005  # make smaller for large libraries, say 0.1 / (library size)
+# when fitting global epistasis models, put this floor on functional scores. "null" or not specifying
+# parameter means no floor.
+func_scores_floor: null
+# when plotting mut effects on viral entry, initially require mutation seen in this many variants:
+muteffects_avg_method: median
+# keyword arguments to `polyclonal.plot.lineplot_and_heatmap` for plotting functional effects
+muteffects_plot_kwargs:
+  addtl_slider_stats:
+    times_seen: 3
+  heatmap_max_at_least: 1
+  heatmap_min_at_least: -1
+  init_floor_at_zero: False
+
+# ----------------------------------------------------------------------------
+# Analysis parameters
 # ----------------------------------------------------------------------------
 
 # Parameters for processing Illumina barcodes
@@ -86,27 +118,6 @@ prob_escape_min_no_antibody_frac: 0.00005  # make smaller for large libraries, s
 # when averaging antibody escape values, take the "median" or "mean"?
 escape_avg_method: median
 
-# Parameters for functional scores and global epistasis analysis
-func_scores_pseudocount: 0.5  # pseudocount when computing functional scores
-func_scores_min_wt_count: 1000  # require this many wildtype counts or error
-func_scores_min_wt_frac:  0.001  # require this fraction of all counts for wildtype or error
-# Only fit global epistasis models for variants with at least this many
-# pre-selection counts and this fraction of total pre-selection counts
-func_scores_min_preselection_counts: 10  # maybe make larger for real expts, say 20 to 50
-func_scores_min_preselection_frac: 0.00005  # make smaller for large libraries, say 0.1 / (library size)
-# when fitting global epistasis models, put this floor on functional scores. "null" or not specifying
-# parameter means no floor.
-func_scores_floor: null
-# when plotting mut effects on viral entry, initially require mutation seen in this many variants:
-muteffects_avg_method: median
-# keyword arguments to `polyclonal.plot.lineplot_and_heatmap` for plotting functional effects
-muteffects_plot_kwargs:
-  addtl_slider_stats:
-    times_seen: 3
-  heatmap_max_at_least: 1
-  heatmap_min_at_least: -1
-  init_floor_at_zero: False
-
 # do we add formatting to the antibody escape and functional effects plots
 format_antibody_escape_plots: true  # if option missing defaults to true
 format_muteffects_plots: true  # if option missing defaults to true
@@ -115,7 +126,7 @@ antibody_escape_legend: null
 muteffects_legend: null
 
 # ----------------------------------------------------------------------------
-# Input data to dms-vep-pipeline downstream of building codon variants
+# Input data
 # ----------------------------------------------------------------------------
 
 # Map sequential 1, 2, numbering of the protein to the desired
@@ -147,7 +158,6 @@ polyclonal_config: data/polyclonal_config.yaml
 # Here we generate this file in `Snakefile` from a known PDB: you can do that,
 # or create it manually.
 spatial_distances: results/spatial_distances/7tov.csv
-
 
 # ----------------------------------------------------------------------------
 # Names of output directories / files


### PR DESCRIPTION
- add option to use pre-built mutational effects.
 - Enables use of functional scores from another repo, do not calculate here. Useful for small repos that for instance might add another antibody to an already extensively studied library.
 - Add `prebuilt_muteffects` option in `config.yaml`.
 - Move functional score computation from `pipeline.smk` to `func_scores.smk`

Becomes version 1.7.0