### PR TITLE
separate `conda` env for `align_parse_PacBio_ccs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### version 2.1.0
+- Added `environment_align_parse_PacBio_ccs.yml` environment specific to the `align_parse_PacBio_ccs` rule so that long-running rule isn't re-run every time main environment in `environment.yml` is updated.
+
 #### version 2.0.1
 - Update `polyclonal` to 4.1.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To display the HTML documentation via GitHub pages, set up your repo to serve do
 The documentation will then be at `https://dms-vep.github.io/<my_dms_repo>` (assuming you are using the [https://github.com/dms-vep](https://github.com/dms-vep) organization; otherwise replace `dms-vep` with whatever account contains your repo).
 
 Note that [dms-vep-pipeline](https://github.com/dms-vep/dms-vep-pipeline) has its own [conda](https://docs.conda.io/) environment specified in [environment.yml](environment.yml).
-Hopefully you can just use this environment for your top-level `Snakefile` too, but if not you can specify rule-specific environments for any additional rules you use.
+There is a separate environment, [environment_align_parse_PacBio_ccs.yml](environment_align_parse_PacBio_ccs.yml), for aligning and parsing the PacBio CCSs so that isn't re-run every time main environment is updated.
 
 ## Setting up the pipeline as a submodule
 To add [dms-vep-pipeline](https://github.com/dms-vep/dms-vep-pipeline) as a [submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) in your repo (`<my_dms_repo>`), do as follows.

--- a/build_variants.smk
+++ b/build_variants.smk
@@ -70,7 +70,7 @@ else:
         output:
             outdir=directory(os.path.join(config["process_ccs_dir"], "{pacbioRun}")),
         conda:
-            "environment.yml"
+            "environment_align_parse_PacBio_ccs.yml"
         log:
             os.path.join(config["logdir"], "align_parse_PacBio_ccs_{pacbioRun}.txt"),
         script:

--- a/environment_align_parse_PacBio_ccs.yml
+++ b/environment_align_parse_PacBio_ccs.yml
@@ -1,0 +1,12 @@
+name: dms-vep-pipeline_align_parse_PacBio_ccs
+channels:
+  - conda-forge
+  - defaults
+  - bioconda
+
+dependencies:
+  - mafft=7.515
+  - minimap2=2.24
+  - pandas=1.5
+  - pip:
+    - alignparse==0.6.0


### PR DESCRIPTION
Means this rule (longest running one) is not re-run everytime you update the main `conda`  environment as long as you run `snakemake` with `--use-conda`

@Bernadetadad, this should somewhat address the issues with having to re-run everything every time there is a minor update. 